### PR TITLE
Mock builder improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+### [0.4.1(34)](https://github.com/rezojoglidze/RJSwiftMacros/releases/tag/0.4.1) — *26 08 2024*
+-  Add `Set` collection type, `passthroughSubject` and `currentValueSubject`  support to `MockBuilderMacro`.
+
 ### [0.4.0(33)](https://github.com/rezojoglidze/RJSwiftMacros/releases/tag/0.4.0) — *23 08 2024*
 -  Refactor `MockBuilderMacro` property generation flow. Make generated properties more readable and understandable for the user.
   

--- a/Sources/Example/main.swift
+++ b/Sources/Example/main.swift
@@ -43,6 +43,8 @@ struct Person {
     
     let closureVariable: () -> Void
     @MockBuilderProperty(value: "k") let character: Character
+    
+    let availableTimeSlot: Set<String>
 }
 
 @MockBuilder(numberOfItems: 2)

--- a/Sources/Example/main.swift
+++ b/Sources/Example/main.swift
@@ -28,6 +28,7 @@ struct CombineExample {
 @CodingKeys(codingKeyType: .snakeCase)
 @MockBuilder(numberOfItems: 2)
 struct Person {
+    @MockBuilderProperty(value: Optional<String>.none)
     let name: String?
     let tuples: (((String, String, Int), Bool?), String)?
     

--- a/Sources/Example/main.swift
+++ b/Sources/Example/main.swift
@@ -6,6 +6,7 @@
 //`
 
 import SwiftUI
+import Combine
 import RJSwiftMacros
 import RJSwiftMacrosImplDependencies
 
@@ -14,6 +15,14 @@ enum VehicleType: String, Decodable {
     case car
     case bus
     case motorcycle
+}
+
+@MockBuilder()
+struct CombineExample {
+    let passthroughSubject: PassthroughSubject<Bool, Never>
+    let currentValueSubject: CurrentValueSubject<Void, Never>
+    let currentValueSubject2: CurrentValueSubject<String, Never>
+    let currentValueSubject3: CurrentValueSubject<(String, Bool), Never>
 }
 
 @CodingKeys(codingKeyType: .snakeCase)

--- a/Sources/RJSwiftCommon/DataGenerator/DataGenerator.swift
+++ b/Sources/RJSwiftCommon/DataGenerator/DataGenerator.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Combine
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
@@ -13,37 +14,54 @@ fileprivate typealias Provider = MockDataProvider
 
 // MARK: - ❗⚠️❗Keep all cases names in lowercase.❗⚠️❗
 // MARK: ❗⚠️❗if type isn't supported from MockBuilderItem macro add it to `notSupportedTypesFromMockBuilderProperty`.❗⚠️❗
-public enum MockBuilderSupportedType: Equatable {    
+public enum MockBuilderSupportedType: Equatable {  
+    // Fundamental data types
     case int(ExprSyntax? = nil)
     case int8(ExprSyntax? = nil)
     case int16(ExprSyntax? = nil)
     case int32(ExprSyntax? = nil)
     case int64(ExprSyntax? = nil)
+    
     case uint(ExprSyntax? = nil)
     case uint8(ExprSyntax? = nil)
     case uint16(ExprSyntax? = nil)
     case uint32(ExprSyntax? = nil)
     case uint64(ExprSyntax? = nil)
+    
     case float(ExprSyntax? = nil)
     case float32(ExprSyntax? = nil)
     case float64(ExprSyntax? = nil)
+    
     case double(ExprSyntax? = nil)
+    
     case decimal(ExprSyntax? = nil)
     case nsdecimalnumber(ExprSyntax? = nil)
+    
     case character(ExprSyntax? = nil)
     case string(ExprSyntax? = nil)
+    
     case bool(ExprSyntax? = nil)
+    
+    // Other similar types
     case date
     case uuid(ExprSyntax? = nil)
     case objectidentifier
+    
     case cgpoint
     case cgrect
     case cgsize
     case cgvector
     case cgfloat
+    
     case url(ExprSyntax? = nil)
+    
+    // SwiftUI
     case image(ExprSyntax? = nil)
     case color(ExprSyntax? = nil)
+    
+    // Combine
+    case passthroughSubject(ExprSyntax? = nil)
+    case currentValueSubject(ExprSyntax? = nil)
     
     // MARK: Initialiazer
     public init?(
@@ -81,6 +99,8 @@ public enum MockBuilderSupportedType: Equatable {
         case "url": self = .url(exprSyntax)
         case "image": self = .image(exprSyntax)
         case "color" : self = .color(exprSyntax)
+        case "passthroughsubject": self = .passthroughSubject(exprSyntax)
+        case "currentvaluesubject": self = .currentValueSubject(exprSyntax)
         default: return nil
         }
     }
@@ -139,11 +159,13 @@ public enum MockBuilderSupportedType: Equatable {
         case .url: getName(of: URL.self)
         case .image: getName(of: Image.self)
         case .color: getName(of: Color.self)
+        case .passthroughSubject: "PassthroughSubject"
+        case .currentValueSubject: "CurrentValueSubject"
         }
     }
     
     // MARK: Expr Syntax
-    public func exprSyntax() -> ExprSyntax {
+    public func exprSyntax(with propertyInitializationExprSyntax: ExprSyntax? = nil) -> ExprSyntax {
         let defaultMaxValue = 100000
         
         return switch self {
@@ -188,6 +210,9 @@ public enum MockBuilderSupportedType: Equatable {
         case .url(let exprSyntax): exprSyntax ?? ExprSyntax(stringLiteral: "URL(string: \"\(Provider().url().absoluteString)\")!")
         case .image(let exprSyntax): exprSyntax ?? ExprSyntax(stringLiteral: Provider().randomImageStringName())
         case .color(let exprSyntax): exprSyntax ?? ExprSyntax(stringLiteral: Provider().randomColorString())
+            
+        case .passthroughSubject(let exprSyntax): exprSyntax ?? (propertyInitializationExprSyntax ?? ExprSyntax(stringLiteral: .empty))
+        case .currentValueSubject(let exprSyntax): exprSyntax ??  (propertyInitializationExprSyntax ?? ExprSyntax(stringLiteral: .empty))
         }
     }
 }

--- a/Sources/RJSwiftCommon/Extensions/TypeSyntax+Extension.swift
+++ b/Sources/RJSwiftCommon/Extensions/TypeSyntax+Extension.swift
@@ -26,6 +26,10 @@ public extension TypeSyntax {
         self.as(ClassRestrictionTypeSyntax.self) != nil
     }
     
+    var isSet: Bool {
+        self.as(IdentifierTypeSyntax.self)?.name.text == "Set" //TypeSyntax doesn't have SetTypeSyntax type.
+    }
+    
     var isOptional: Bool {
         self.as(OptionalTypeSyntax.self) != nil
     }

--- a/Sources/RJSwiftMacrosImpl/Attached/MockBuilderMacros/MockBuilder/MockBuilderMacro+ExprSyntax.swift
+++ b/Sources/RJSwiftMacrosImpl/Attached/MockBuilderMacros/MockBuilder/MockBuilderMacro+ExprSyntax.swift
@@ -31,6 +31,11 @@ extension MockBuilderMacro {
                 dictionaryType: type,
                 initialValue: initialValue
             )
+        } else if type.isSet {
+            return getSetExprSyntax(
+                from: type,
+                initialValue: initialValue
+            )
         } else {
             return getSimpleExprSyntax(
                 simpleTypeSyntax: type,
@@ -107,7 +112,22 @@ extension MockBuilderMacro {
         return nil
     }
     
-    // MARK: Get Simple Expr Syntax
+    // MARK: Get Set Expr Syntax
+    private static func getSetExprSyntax(
+        from type: TypeSyntax,
+        initialValue: ExprSyntax?
+    ) -> ExprSyntax {
+        let setExprSyntax = FunctionCallExprSyntax(
+            calledExpression: ExprSyntax(stringLiteral: type.description),
+            leftParen: .leftParenToken(),
+            arguments: [],
+            rightParen: .rightParenToken()
+        )
+     
+        return initialValue ?? ExprSyntax(setExprSyntax)
+    }
+    
+    // MARK: - Get Simple Expr Syntax
     private static func getSimpleExprSyntax<T: TypeSyntaxProtocol>(
         simpleTypeSyntax: T,
         initialValue: ExprSyntax?

--- a/Sources/RJSwiftMacrosImpl/Attached/MockBuilderMacros/MockBuilder/MockBuilderMacro+ExprSyntax.swift
+++ b/Sources/RJSwiftMacrosImpl/Attached/MockBuilderMacros/MockBuilder/MockBuilderMacro+ExprSyntax.swift
@@ -112,9 +112,12 @@ extension MockBuilderMacro {
         simpleTypeSyntax: T,
         initialValue: ExprSyntax?
     ) -> ExprSyntax? {
-        // Investigate is in progress, trying to find better solution. TODO: Refactor it
-        if initialValue.debugDescription == Constants.nilTypeOptionalDebugDescription.rawValue {
-            return ExprSyntax(stringLiteral: "nil")
+        if checkIfInitialValueIsNil(initialValue: initialValue) {
+            return ExprSyntax(
+                DeclReferenceExprSyntax(
+                    baseName: .init(stringLiteral: "nil")
+                )
+            )
         } else if let simpleIdentifierType = simpleTypeSyntax.as(IdentifierTypeSyntax.self) {
             return getSimpleExprSyntaxForIdentifierType(
                 simpleIdentifierType: simpleIdentifierType,
@@ -137,6 +140,29 @@ extension MockBuilderMacro {
         } else {
             return nil
         }
+    }
+    
+    // MARK: Check If Initial Value Is Nil
+    private static func checkIfInitialValueIsNil(
+        initialValue: ExprSyntax?
+    ) -> Bool {
+        guard let initialValue else { return false }
+        
+        if initialValue
+            .as(MemberAccessExprSyntax.self)?.base?
+            .as(GenericSpecializationExprSyntax.self)?.expression
+            .as(DeclReferenceExprSyntax.self)?.baseName.text == "Optional" &&
+            
+            initialValue
+            .as(MemberAccessExprSyntax.self)?.period.tokenKind == .period &&
+            
+            initialValue
+            .as(MemberAccessExprSyntax.self)?.declName.baseName.text == "none" {
+            
+            return true
+        }
+        
+        return false
     }
     
     // MARK: Get Simple Expr Syntax For Tuple Type Syntax

--- a/Sources/RJSwiftMacrosImpl/Attached/MockBuilderMacros/MockBuilder/MockBuilderMacro+ExprSyntax.swift
+++ b/Sources/RJSwiftMacrosImpl/Attached/MockBuilderMacros/MockBuilder/MockBuilderMacro+ExprSyntax.swift
@@ -39,6 +39,7 @@ extension MockBuilderMacro {
         }
     }
     
+    // MARK: Get Array Expr Syntax
     private static func getArrayExprSyntax(
         arrayType: ArrayTypeSyntax,
         initialValue: ExprSyntax?
@@ -77,6 +78,7 @@ extension MockBuilderMacro {
         return nil
     }
     
+    // MARK: Get Dictionary Expr Syntax
     private static func getDictionaryExprSyntax(
         dictionaryType: DictionaryTypeSyntax,
         initialValue: ExprSyntax?
@@ -105,7 +107,7 @@ extension MockBuilderMacro {
         return nil
     }
     
-    // MARK: Simple Expr Syntax Methods
+    // MARK: Get Simple Expr Syntax
     private static func getSimpleExprSyntax<T: TypeSyntaxProtocol>(
         simpleTypeSyntax: T,
         initialValue: ExprSyntax?

--- a/Sources/RJSwiftMacrosImpl/Attached/MockBuilderMacros/MockBuilder/MockBuilderMacro.swift
+++ b/Sources/RJSwiftMacrosImpl/Attached/MockBuilderMacros/MockBuilder/MockBuilderMacro.swift
@@ -88,6 +88,9 @@ extension MockBuilderMacro {
         let singleMockItemCode = VariableDeclSyntax(
             modifiers: DeclModifierListSyntax {
                 DeclModifierSyntax(
+                    name: .keyword(.public)
+                )
+                DeclModifierSyntax(
                     name: .keyword(.static)
                 )
             },
@@ -120,6 +123,9 @@ extension MockBuilderMacro {
                     modifiers: DeclModifierListSyntax {
                         DeclModifierSyntax(
                             leadingTrivia: .newline,
+                            name: .keyword(.public)
+                        )
+                        DeclModifierSyntax(
                             name: .keyword(.static)
                         )
                     },


### PR DESCRIPTION
-  Add `Set` collection type, `passthroughSubject` and `currentValueSubject`  support to `MockBuilderMacro`.
